### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/pathTravese_sample1.py
+++ b/pathTravese_sample1.py
@@ -68,6 +68,10 @@ def article():
 
     if 'name' in request.args:
         page = request.args.get('name')
+        base_path = '/home/golem/articles'
+        full_path = os.path.normpath(os.path.join(base_path, page))
+        if not full_path.startswith(base_path):
+            full_path = os.path.join(base_path, 'notallowed.txt')
     else:
         page = 'article'
 
@@ -75,7 +79,7 @@ def article():
         page = 'notallowed.txt'
 
     try:
-        template = open('/home/golem/articles/{}'.format(page)).read()
+        template = open(full_path).read()
     except Exception as e:
         template = e
 


### PR DESCRIPTION
Potential fix for [https://github.com/mukeshmak123/copilot-autofix/security/code-scanning/20](https://github.com/mukeshmak123/copilot-autofix/security/code-scanning/20)

To fix the problem, we need to ensure that the `page` variable is validated and sanitized before being used in the file path expression. We can achieve this by normalizing the path and ensuring it is contained within a safe root directory. This will prevent path traversal attacks by disallowing any attempts to access files outside the intended directory.

1. Normalize the `page` variable using `os.path.normpath`.
2. Ensure the normalized path starts with the safe root directory.
3. If the path is not valid, set it to a default safe value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
