### PR TITLE
Potential fix for code scanning alert no. 38: Log entries created from user input

### DIFF
--- a/logf.cs
+++ b/logf.cs
@@ -24,7 +24,8 @@ namespace WebFox.Controllers
         [HttpGet("{userInfo}")]
         public void injectLog(string userInfo)
         {
-            _logger.LogError("error!! " + userInfo);
+            string sanitizedUserInfo = userInfo.Replace("\n", "").Replace("\r", "");
+            _logger.LogError("error!! " + sanitizedUserInfo);
         }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/mukeshmak123/copilot-autofix/security/code-scanning/38](https://github.com/mukeshmak123/copilot-autofix/security/code-scanning/38)

To fix the issue, we need to sanitize the `userInfo` parameter before logging it. Since the logs are likely plain text, we should remove any newline characters or other potentially harmful characters from the user input. This can be achieved using `String.Replace` or similar methods to ensure that the input is safe for logging.

**Steps to fix:**
1. Replace newline characters (`\n` and `\r`) in the `userInfo` string with an empty string to prevent log forgery.
2. Use the sanitized version of `userInfo` in the logging statement.

The changes will be made in the `injectLog` method in the `logf.cs` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
